### PR TITLE
remove workspace samples/notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "incidents-app",
     "samples/audit-logging",
     "samples/change-tracking",
-    "samples/notifications",
     "plugins/*"
   ]
 }


### PR DESCRIPTION
breaks npm install because @cap-js/notifications is not on npm